### PR TITLE
minor updates for zshcomp

### DIFF
--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -55,7 +55,7 @@ _yo_context() {
 # }}}
 # yo resources  {{{
 _yo_instances() {
-  local filter='.instances.cache[] | "\(.name | gsub(":"; "\\:")):\(.shape) [\(.state)]"'
+  local filter='.instances.cache[] | select(.state != "TERMINATED") | "\(.name | gsub(":"; "\\:")):\(.shape) [\(.state)]"'
   local -Ua instances=(${(@f)"$(_call_program yo-instances jq -r ${(q)filter} $caches)"})
   if [[ -z ${exact_name:-${opt_args[(I)-E|--exact-name]}} ||
         -n ${exact_name+$opt_args[(I)--no-exact-name]} ]]; then
@@ -83,7 +83,7 @@ _yo_images() {
 }
 
 _yo_volumes() {
-  local filter='.bootvols.cache[] |
+  local filter='.bootvols.cache[] | select(.state != "TERMINATED") |
     "\(.name | gsub(":"; "\\:")):\(.name | gsub(":"; "\\:")) \(.size_in_gbs)GB [\(.state)]"'
   local -a volumes=(${(@f)"$(_call_program yo-volumes jq -r ${(q)filter} $caches)"})
 

--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -454,7 +454,7 @@ local -a _yo_volume_detach_options=(
   '--no-exact-name[Always prefix the instance name with your username]'
   '--no-teardown[Do not run iSCSI teardown commands]'
   + '(volume-detach-which)'
-  '--from[Instance to detach from if there are multiple]'
+  '--from=[Instance to detach from if there are multiple]:instance:_yo_instances'
   '--all[Detach from all instances]'
 )
 

--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -71,7 +71,7 @@ _yo_shapes() {
     + if .local_disks > 0 then " / \(.local_disks_total_size_in_gbs)GB \(.local_disk_description)" else "" end'
   local -a shapes=(${(@f)"$(_call_program yo-shapes jq -r ${(q)filter} $caches)"})
 
-  _describe -t yo-shapes "shape" shapes "$@"
+  _describe -t yo-shapes "shape" shapes -M 'm:{[:lower:]}={[:upper:]} r:|.=*' "$@"
 }
 
 _yo_images() {


### PR DESCRIPTION
These are some small changes added to my completions since the last release. First, hide TERMINATED instances in most cases, and second complete shape names a little better so that yo can complete e.g.

```
$ yo launch -S flex|<TAB>
$ yo launch -S VM.|.Flex
VM.DenseIO.E4.Flex   -- VM.DenseIO.E4.Flex / 16.0GB / 6800.0GB NVMe SSD Storage
VM.Optimized3.Flex   -- VM.Optimized3.Flex / 14.0GB
VM.Standard.A1.Flex  -- VM.Standard.A1.Flex / 6.0GB
VM.Standard.E3.Flex  -- VM.Standard.E3.Flex / 16.0GB
VM.Standard.E4.Flex  -- VM.Standard.E4.Flex / 16.0GB
VM.Standard.E5.Flex  -- VM.Standard.E5.Flex / 12.0GB
VM.Standard3.Flex    -- VM.Standard3.Flex / 16.0GB
```