### PR TITLE
Update zsh completions

### DIFF
--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -56,7 +56,7 @@ _yo_context() {
 # yo resources  {{{
 _yo_instances() {
   local filter='.instances.cache[] | select(.state != "TERMINATED") | "\(.name | gsub(":"; "\\:")):\(.shape) [\(.state)]"'
-  local -Ua instances=(${(@f)"$(_call_program yo-instances jq -r ${(q)filter} $caches)"})
+  local -Ua instances=(${(@f)"$(_call_program -l yo-instances jq -r ${(q)filter} $caches)"})
   if [[ -z ${exact_name:-${opt_args[(I)-E|--exact-name]}} ||
         -n ${exact_name+$opt_args[(I)--no-exact-name]} ]]; then
           instances+=(${instances#$USER-})
@@ -69,7 +69,7 @@ _yo_instances() {
 _yo_shapes() {
   local filter='.shapes.cache[] | "\(.name):\(.name ) / \(.memory_in_gbs)GB"
     + if .local_disks > 0 then " / \(.local_disks_total_size_in_gbs)GB \(.local_disk_description)" else "" end'
-  local -a shapes=(${(@f)"$(_call_program yo-shapes jq -r ${(q)filter} $caches)"})
+  local -a shapes=(${(@f)"$(_call_program -l yo-shapes jq -r ${(q)filter} $caches)"})
 
   _describe -t yo-shapes "shape" shapes -M 'm:{[:lower:]}={[:upper:]} r:|.=*' "$@"
 }
@@ -85,15 +85,15 @@ _yo_images() {
   _tags yo-images-os yo-images-custom yo-images-named
   while _tags; do
     if _requested yo-images-os; then
-      ((#images_os)) || images_os=(${(@f)"$(_call_program yo-images-os jq -r ${(q)filter_os} $caches)"})
+      ((#images_os)) || images_os=(${(@f)"$(_call_program -l yo-images-os jq -r ${(q)filter_os} $caches)"})
      _all_labels yo-images-os expl "OS image" _multi_parts -i : images_os && ret=0
     fi
     if _requested yo-images-custom; then
-      ((#images_custom)) || images_custom=(${(@f)"$(_call_program yo-images-custom jq -r ${(q)filter_custom} $caches)"})
+      ((#images_custom)) || images_custom=(${(@f)"$(_call_program -l yo-images-custom jq -r ${(q)filter_custom} $caches)"})
      _all_labels yo-images-custom expl "custom image" compadd -a - images_custom && ret=0
     fi
     if ((ret)) && _requested yo-images-named; then
-      ((#images_named)) || images_named=(${(@f)"$(_call_program yo-images-named jq -r ${(q)filter_name} $caches)"})
+      ((#images_named)) || images_named=(${(@f)"$(_call_program -l yo-images-named jq -r ${(q)filter_name} $caches)"})
       _all_labels yo-images-named expl "named image" compadd -a - images_named && ret=0
     fi
     ((ret)) || break
@@ -104,14 +104,14 @@ _yo_images() {
 _yo_volumes() {
   local filter='.bootvols.cache[] | select(.state != "TERMINATED") |
     "\(.name | gsub(":"; "\\:")):\(.name | gsub(":"; "\\:")) \(.size_in_gbs)GB [\(.state)]"'
-  local -a volumes=(${(@f)"$(_call_program yo-volumes jq -r ${(q)filter} $caches)"})
+  local -a volumes=(${(@f)"$(_call_program -l yo-volumes jq -r ${(q)filter} $caches)"})
 
   _describe -t yo-volumes "volume" volumes "$@"
 }
 
 _yo_ads() {
   local filter='.ads.cache[].name | gsub(":"; "\\:")'
-  local -a ads=(${(@f)"$(_call_program yo-ads jq -r ${(q)filter} $caches)"})
+  local -a ads=(${(@f)"$(_call_program -l yo-ads jq -r ${(q)filter} $caches)"})
 
   _describe -t yo-ads "availability domain" ads "$@"
 }
@@ -615,7 +615,7 @@ fi
 _yo_prep_cmd() {
   # yuck
   local region_default_sed_pattern='/\[yo\]/,/^ *\[/ s/^ *region *= *([a-z0-9-]+)/\1/p'
-  local region_default="$(_call_program yo-region-default sed -En ${(q)region_default_sed_pattern} ~/.oci/yo.ini)"
+  local region_default="$(_call_program -l yo-region-default sed -En ${(q)region_default_sed_pattern} ~/.oci/yo.ini)"
   local region=${YO_REGION:-${(v)opt_args[(I)-r|--region]}}
   region=${region:-$region_default}
   local -a caches=( ~/.cache/yo.${region:-*}.json(N.) )
@@ -624,12 +624,12 @@ _yo_prep_cmd() {
 }
 
 # also yuck
-local exact_name="$(_call_program yo-exact-name grep -E ${(q):-'^ *exact_name *= *true'} ~/.oci/yo.ini)"
+local exact_name="$(_call_program -l yo-exact-name grep -E ${(q):-'^ *exact_name *= *true'} ~/.oci/yo.ini)"
 local -a _yo_regions=(
-  ${${(@f)"$(_call_program yo-regions grep -Eo ${(q):-'^ *\[regions.([a-z0-9-]+)'} ~/.oci/yo.ini)"}# #\[regions.}
+  ${${(@f)"$(_call_program -l yo-regions grep -Eo ${(q):-'^ *\[regions.([a-z0-9-]+)'} ~/.oci/yo.ini)"}# #\[regions.}
 )
 local -a _yo_profiles=(
-  ${${(@f)"$(_call_program yo-profiles grep -Eo ${(q):-'^ *\[instances.([a-z0-9-]+)'} ~/.oci/yo.ini)"}# #\[instances.}
+  ${${(@f)"$(_call_program -l yo-profiles grep -Eo ${(q):-'^ *\[instances.([a-z0-9-]+)'} ~/.oci/yo.ini)"}# #\[instances.}
 )
 
 local -a _yo_options=(

--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -80,6 +80,7 @@ _yo_images() {
   local filter_custom='.images.cache[] | select(.os == "Custom" or .os_version == "Custom").name | gsub(":"; "\\:")'
   local -a images_os images_custom images_named
 
+
   local expl ret=1
   _tags yo-images-os yo-images-custom yo-images-named
   while _tags; do
@@ -135,7 +136,7 @@ _yo_list_command() {
   )
   _arguments -S -A '*' $_yo_list_options
 }
-local -a yo_list_command=(/$'[^\0]#\0'/ ': : :_yo_list_command' '#')
+local -a yo_list_command=(/$'[^\0]#\0'/ ':yo-list: :_yo_list_command' '#')
 
 _yo_launch_command() {
   local -a _yo_launch_options=(
@@ -160,7 +161,7 @@ _yo_launch_command() {
   )
   _arguments -S -A '*' $_yo_launch_options
 }
-local -a yo_launch_command=(/$'[^\0]#\0'/ ': : :_yo_launch_command' '#')
+local -a yo_launch_command=(/$'[^\0]#\0'/ ':yo-launch: :_yo_launch_command' '#')
 
 _yo_ssh_command() {
   local -a _yo_ssh_options=(
@@ -177,7 +178,7 @@ _yo_ssh_command() {
     '1:instance:_yo_instances' \
     '*:: := {words[1]=ssh; _normal}'
 }
-local -a yo_ssh_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_ssh_command' '#')
+local -a yo_ssh_command=(/$'[^\0]#\0'/ ':yo-ssh: :_yo_context _yo_ssh_command' '#')
 
 local -a _yo_basic_commands=(
   'list:List your OCI instances:$yo_list_command'
@@ -199,7 +200,7 @@ _yo_rebuild_command() {
   )
   _arguments -S -A '*' $_yo_rebuild_options
 }
-local -a yo_rebuild_command=(/$'[^\0]#\0'/ ': : :_yo_rebuild_command' '#')
+local -a yo_rebuild_command=(/$'[^\0]#\0'/ ':yo-rebuild: :_yo_rebuild_command' '#')
 
 _yo_wait_command() {
   local -a _yo_wait_options=(
@@ -212,7 +213,7 @@ _yo_wait_command() {
     $_yo_wait_options \
     '1:instance:_yo_instances'
 }
-local -a yo_wait_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_wait_command' '#')
+local -a yo_wait_command=(/$'[^\0]#\0'/ ':yo-wait: :_yo_context _yo_wait_command' '#')
 
 _yo_teardown_command() {
   local -a _yo_teardown_options=(
@@ -224,7 +225,7 @@ _yo_teardown_command() {
     $_yo_teardown_options \
     '1:instance:_yo_instances'
 }
-local -a yo_teardown_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_teardown_command' '#')
+local -a yo_teardown_command=(/$'[^\0]#\0'/ ':yo-teardown: :_yo_context _yo_teardown_command' '#')
 
 _yo_rename_command() {
   _arguments -S \
@@ -232,7 +233,7 @@ _yo_rename_command() {
     '1:instance:_yo_instances' \
     '2:new name:()'
 }
-local -a yo_rename_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_rename_command' '#')
+local -a yo_rename_command=(/$'[^\0]#\0'/ ':yo-rename: :_yo_context _yo_rename_command' '#')
 
 _yo_protect_command() {
   _arguments -S \
@@ -240,7 +241,7 @@ _yo_protect_command() {
     '1:instance:_yo_instances' \
     '2:protection setting:(on off)'
 }
-local -a yo_protect_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_protect_command' '#')
+local -a yo_protect_command=(/$'[^\0]#\0'/ ':yo-protect: :_yo_context _yo_protect_command' '#')
 
 _yo_terminate_command() {
   local -a _yo_terminate_options=(
@@ -255,7 +256,7 @@ _yo_terminate_command() {
     $_yo_terminate_options \
     '*:instance:_yo_instances'
 }
-local -a yo_terminate_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_terminate_command' '#')
+local -a yo_terminate_command=(/$'[^\0]#\0'/ ':yo-terminate: :_yo_context _yo_terminate_command' '#')
 
 _yo_resize_command() {
   local -a _yo_resize_options=(
@@ -266,7 +267,7 @@ _yo_resize_command() {
     $_yo_resize_options \
     '1:instance:_yo_instances'
 }
-local -a yo_resize_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_resize_command' '#')
+local -a yo_resize_command=(/$'[^\0]#\0'/ ':yo-resize: :_yo_context _yo_resize_command' '#')
 
 local -a _yo_instance_commands=(
   'rebuild:Rebuild a saved and torn down instance:$yo_rebuild_command'
@@ -292,7 +293,7 @@ _yo_ip_command() {
   )
   _arguments -S -A '*' $_yo_ip_options '*:instance:_yo_instances'
 }
-local -a yo_ip_command=(/$'[^\0]#\0'/ ': : :_yo_ip_command' '#')
+local -a yo_ip_command=(/$'[^\0]#\0'/ ':yo-ip: :_yo_ip_command' '#')
 
 _yo_scp_service() {
   _alternative \
@@ -305,7 +306,7 @@ _yo_scp_command() {
     $_yo_single_instance_options \
     '*:: := _yo_scp_service'
 }
-local -a yo_scp_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_scp_command' '#')
+local -a yo_scp_command=(/$'[^\0]#\0'/ ':yo-scp: :_yo_context _yo_scp_command' '#')
 
 _yo_rsync_service() {
   _alternative \
@@ -323,7 +324,7 @@ _yo_rsync_command() {
     $_yo_single_instance_options \
     '*:: := _yo_rsync_service'
 }
-local -a yo_rsync_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_rsync_command' '#')
+local -a yo_rsync_command=(/$'[^\0]#\0'/ ':yo-rsync: :_yo_context _yo_rsync_command' '#')
 
 _yo_console_command() {
   local -a _yo_console_options=(
@@ -335,7 +336,7 @@ _yo_console_command() {
     $_yo_single_instance_options \
     '1:instance:_yo_instances'
 }
-local -a yo_console_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_console_command' '#')
+local -a yo_console_command=(/$'[^\0]#\0'/ ':yo-console: :_yo_context _yo_console_command' '#')
 
 _yo_copy_id_command() {
   local -a _yo_copy_id_options=(
@@ -347,7 +348,7 @@ _yo_copy_id_command() {
     $_yo_single_instance_options \
     '1:instance:_yo_instances'
 }
-local -a yo_copy_id_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_copy_id_command' '#')
+local -a yo_copy_id_command=(/$'[^\0]#\0'/ ':yo-copy-id: :_yo_context _yo_copy_id_command' '#')
 
 local -a _yo_interactive_commands=(
   'ip:Print the IP address for one or more instances:$yo_ip_command'
@@ -369,7 +370,7 @@ _yo_task_info_command() {
   _arguments -S \
     $n':task:_yo_tasks'
 }
-local -a yo_task_info_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_task_info_command' '#')
+local -a yo_task_info_command=(/$'[^\0]#\0'/ ':yo-task-info: :_yo_context _yo_task_info_command' '#')
 
 _yo_task_run_command() {
   integer n=2-${words[(I)task-*]}
@@ -382,7 +383,7 @@ _yo_task_run_command() {
     $n':instance:_yo_instances' \
       ':task:_yo_tasks'
 }
-local -a yo_task_run_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_task_run_command' '#')
+local -a yo_task_run_command=(/$'[^\0]#\0'/ ':yo-task-run: :_yo_context _yo_task_run_command' '#')
 
 _yo_task_wait_command() {
   integer n=2-${words[(I)task-*]}
@@ -391,7 +392,7 @@ _yo_task_wait_command() {
     $n':instance:_yo_instances' \
       ':task:_yo_tasks'
 }
-local -a yo_task_wait_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_task_wait_command' '#')
+local -a yo_task_wait_command=(/$'[^\0]#\0'/ ':yo-task-wait: :_yo_context _yo_task_wait_command' '#')
 
 _yo_task_single_instance_command() {
   integer n=2-${words[(I)task-*]}
@@ -445,7 +446,7 @@ _yo_volume_create_command() {
     $n':volume name:()' \
       ':size:()'
 }
-local -a yo_volume_create_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_volume_create_command' '#')
+local -a yo_volume_create_command=(/$'[^\0]#\0'/ ':yo-volume-create: :_yo_context _yo_volume_create_command' '#')
 
 _yo_volume_attach_command() {
   integer n=2-${words[(I)volume-*]}
@@ -455,7 +456,7 @@ _yo_volume_attach_command() {
     $n':volume name:_yo_volumes' \
       ':instance name:_yo_instances'
 }
-local -a yo_volume_attach_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_volume_attach_command' '#')
+local -a yo_volume_attach_command=(/$'[^\0]#\0'/ ':yo-volume-attach: :_yo_context _yo_volume_attach_command' '#')
 
 _yo_volume_rename_command() {
   integer n=2-${words[(I)volume-*]}
@@ -466,7 +467,7 @@ _yo_volume_rename_command() {
     $n':old name:_yo_volumes' \
       ':new name:()'
 }
-local -a yo_volume_rename_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_volume_rename_command' '#')
+local -a yo_volume_rename_command=(/$'[^\0]#\0'/ ':yo-volume-rename: :_yo_context _yo_volume_rename_command' '#')
 
 local -a _yo_volume_detach_options=(
   '(-E --exact-name)'{-E,--exact-name}'[Do not prefix the instance name with your username]'
@@ -483,7 +484,7 @@ _yo_volume_detach_command() {
     + volume\
     $n':volume:_yo_volumes'
 }
-local -a yo_volume_detach_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_volume_detach_command' '#')
+local -a yo_volume_detach_command=(/$'[^\0]#\0'/ ':yo-volume-detach: :_yo_context _yo_volume_detach_command' '#')
 
 _yo_volume_delete_command() {
   integer n=2-${words[(I)volume-*]}
@@ -496,7 +497,7 @@ _yo_volume_delete_command() {
     + volume \
     $n':name:_yo_volumes'
 }
-local -a yo_volume_delete_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_volume_delete_command' '#')
+local -a yo_volume_delete_command=(/$'[^\0]#\0'/ ':yo-volume-delete: :_yo_context _yo_volume_delete_command' '#')
 
 local -a _yo_volume_commands=(
   'list:List block and boot volumes'
@@ -524,7 +525,7 @@ _yo_images_command() {
   )
   _arguments -S $_yo_images_options '1:image:_yo_images'
 }
-local -a yo_images_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_images_command' '#')
+local -a yo_images_command=(/$'[^\0]#\0'/ ':yo-images: :_yo_context _yo_images_command' '#')
 
 _yo_shapes_command() {
   local -a filters=(bm vm amd intel arm flex gpu disk)
@@ -538,7 +539,7 @@ _yo_shapes_command() {
   )
   _arguments -S -A '*' $_yo_shapes_options
 }
-local -a yo_shapes_command=(/$'[^\0]#\0'/ ': : :_yo_shapes_command' '#')
+local -a yo_shapes_command=(/$'[^\0]#\0'/ ':yo-shapes: :_yo_shapes_command' '#')
 
 _yo_compat_command() {
   local -a _yo_compat_options=(
@@ -550,10 +551,10 @@ _yo_compat_command() {
   )
   _arguments -S -A '*' $_yo_compat_options
 }
-local -a yo_compat_command=(/$'[^\0]#\0'/ ': : :_yo_compat_command' '#')
+local -a yo_compat_command=(/$'[^\0]#\0'/ ':yo-compat: :_yo_compat_command' '#')
 
 _yo_shape_command() { _arguments -S '1:shape:_yo_shapes' }
-local -a yo_shape_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_shape_command' '#')
+local -a yo_shape_command=(/$'[^\0]#\0'/ ':yo-shape: :_yo_context _yo_shape_command' '#')
 
 _yo_limits_command()  {
   local -a _yo_limits_options=(
@@ -562,7 +563,7 @@ _yo_limits_command()  {
   )
   _arguments -S -A '*' $_yo_limits_options
 }
-local -a yo_limits_command=(/$'[^\0]#\0'/ ': : :_yo_limits_command' '#')
+local -a yo_limits_command=(/$'[^\0]#\0'/ ':yo-limits: :_yo_limits_command' '#')
 
 local -a _yo_info_commands=(
   'im*ages:List images available to use for launching an instance:$yo_images_command'

--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -233,9 +233,9 @@ _yo_terminate_command() {
   )
 
   _arguments -S \
-    $_yo_single_instance_options \
+    $_yo_multi_instance_options \
     $_yo_terminate_options \
-    '1:instance:_yo_instances'
+    '*:instance:_yo_instances'
 }
 local -a yo_terminate_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_terminate_command' '#')
 
@@ -432,6 +432,7 @@ local -a yo_volume_create_command=(/$'[^\0]#\0'/ ': : :_yo_context _yo_volume_cr
 _yo_volume_attach_command() {
   integer n=2-${words[(I)volume-*]}
   _arguments -S $_yo_volume_attach_options \
+    '--as-boot[Attach as a boot volume]' \
     + volume \
     $n':volume name:_yo_volumes' \
       ':instance name:_yo_instances'

--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -615,9 +615,10 @@ fi
 _yo_prep_cmd() {
   # yuck
   local region_default_sed_pattern='/\[yo\]/,/^ *\[/ s/^ *region *= *([a-z0-9-]+)/\1/p'
-  local region_default="$(_call_program -l yo-region-default sed -En ${(q)region_default_sed_pattern} ~/.oci/yo.ini)"
   local region=${YO_REGION:-${(v)opt_args[(I)-r|--region]}}
-  region=${region:-$region_default}
+  if [[ -z $region ]]; then
+    region="$(_call_program -l yo-region-default sed -En ${(q)region_default_sed_pattern} ~/.oci/yo.ini)"
+  fi
   local -a caches=( ~/.cache/yo.${region:-*}.json(N.) )
 
   _yo_cmd "$@"

--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -443,6 +443,7 @@ _yo_volume_create_command() {
   )
   _arguments -S $_yo_volume_create_options \
     $_yo_volume_attach_options \
+    + -default- \
     $n':volume name:()' \
       ':size:()'
 }
@@ -452,7 +453,7 @@ _yo_volume_attach_command() {
   integer n=2-${words[(I)volume-*]}
   _arguments -S $_yo_volume_attach_options \
     '--as-boot[Attach as a boot volume]' \
-    + volume \
+    + -default- \
     $n':volume name:_yo_volumes' \
       ':instance name:_yo_instances'
 }

--- a/contrib/yo.zsh
+++ b/contrib/yo.zsh
@@ -129,7 +129,7 @@ _yo_list_command() {
   local -a _yo_list_options=(
     '(-c --cached)'{-c,--cached}'[Avoid loading and calling OCI]'
     '(-C --columns)'{-C+,--columns=}'[Specify all columns in the table]:column:('"$columns"')'
-    '(-x --extra-column)'{-x+,--extra-column=}'[Add a column to the table]:column:('"$columns"')'
+    \*{-x+,--extra-column=}'[Add a column to the table]:column:('"$columns"')'
     '(-i --ip)'{-i,--ip}'[Include the IP address column]'
     '--ad[Include the availability domain column]'
     '(-a --all)'{-a,--all}'[Display all instances in the compartment]'
@@ -155,7 +155,7 @@ _yo_launch_command() {
     '--no-exact-name[Always not prefix the instance name with your username]'
     '--dry-run[Do not launch an instance, but print what would be done]'
     '(-p --profile)'{-p+,--profile=}'[Profile to use]:profile:('"$_yo_profiles"')'
-    '(-t --task)'{-t+,--task=}'[Tasks to run once the instance is up]:task:_yo_tasks'
+    \*{-t+,--task=}'[Tasks to run once the instance is up]:task:_yo_tasks'
     '--load-image=[Strategy for loading images]:strategy:(UNIQUE LATEST)'
     '(-u --username)'{-u+,--username=}'[Username for logging into the instance]:user:_users'
   )
@@ -536,7 +536,7 @@ _yo_shapes_command() {
     '--disk[Display details disk information]'
     '--gpu[Display detailed GPU information]'
     '(-a --availability)'{-a,--availability}'[Display availability across domains]'
-    {-f+,--filter=}'[Filter to shapes with particular features]:filter:('"$filters"')'
+    \*{-f+,--filter=}'[Filter to shapes with particular features]:filter:('"$filters"')'
   )
   _arguments -S -A '*' $_yo_shapes_options
 }


### PR DESCRIPTION
This is the tip of my zshcomp branch, with just a few changes I've made since last time from fixing whatever bumps that I run into.

Adds the --as-boot option,  completes custom image names, and fixes some quirky behavior with _next_tags completer.

bugs: custom image names other than "os:version" aren't actually valid everywhere the image helper is used, but are always considered valid completions.