### PR TITLE
Allow detaching a volume from stopped instance

### DIFF
--- a/yo/main.py
+++ b/yo/main.py
@@ -3135,7 +3135,7 @@ class DetachCmd(YoCmd):
         if self.args.from_instance:
             inst = self.c.get_instance_by_name(
                 self.args.from_instance,
-                ("RUNNING",),
+                ("RUNNING", "STOPPING", "STOPPED"),
                 (),
                 exact_name=self.args.exact_name,
             )


### PR DESCRIPTION
The user must take care not to use the options that would SSH into the instance to run the teardown commands.